### PR TITLE
feat: Add custom SSO login page with provider selection

### DIFF
--- a/litellm/proxy/common_utils/html_forms/sso_login.py
+++ b/litellm/proxy/common_utils/html_forms/sso_login.py
@@ -1,0 +1,272 @@
+import os
+
+def get_sso_login_template(redirect_url: str, providers: dict) -> str:
+    """
+    Generate SSO login page HTML template matching the original login form design
+    
+    Args:
+        redirect_url: The callback URL for OAuth
+        providers: Dict with provider info {'google': True, 'microsoft': False, etc.}
+    """
+    server_root_path = os.getenv("SERVER_ROOT_PATH", "")
+    proxy_base_url = os.getenv("PROXY_BASE_URL", "")
+    
+    # Build the actual redirect URL for the SSO provider
+    sso_redirect_url = f"{proxy_base_url}{server_root_path}/sso/redirect"
+    
+    html_template = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Raypath Login</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background-color: #f8fafc;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            color: #333;
+        }}
+
+        .login-container {{
+            background-color: #fff;
+            padding: 40px;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+            width: 450px;
+            max-width: 100%;
+        }}
+        
+        .logo-container {{
+            text-align: center;
+            margin-bottom: 30px;
+        }}
+        
+        .logo {{
+            font-size: 24px;
+            font-weight: 600;
+            color: #1e293b;
+        }}
+        
+        h2 {{
+            margin: 0 0 10px;
+            color: #1e293b;
+            font-size: 28px;
+            font-weight: 600;
+            text-align: center;
+        }}
+        
+        .subtitle {{
+            color: #64748b;
+            margin: 0 0 20px;
+            font-size: 16px;
+            text-align: center;
+        }}
+        
+        .info-box {{
+            background-color: #f1f5f9;
+            border-radius: 6px;
+            padding: 20px;
+            margin-bottom: 30px;
+            border-left: 4px solid #2563eb;
+        }}
+        
+        .info-header {{
+            display: flex;
+            align-items: center;
+            margin-bottom: 12px;
+            color: #1e40af;
+            font-weight: 600;
+            font-size: 16px;
+        }}
+        
+        .info-header svg {{
+            margin-right: 8px;
+        }}
+        
+        .info-box p {{
+            color: #475569;
+            margin: 8px 0;
+            line-height: 1.5;
+            font-size: 14px;
+        }}
+        
+        .gsi-material-button {{
+            -moz-user-select: none;
+            -webkit-user-select: none;
+            -ms-user-select: none;
+            -webkit-appearance: none;
+            background-color: WHITE;
+            background-image: none;
+            border: 1px solid #747775;
+            -webkit-border-radius: 4px;
+            border-radius: 4px;
+            -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+            color: #1f1f1f;
+            cursor: pointer;
+            font-family: 'Roboto', arial, sans-serif;
+            font-size: 14px;
+            height: 40px;
+            letter-spacing: 0.25px;
+            outline: none;
+            overflow: hidden;
+            padding: 0 12px;
+            position: relative;
+            text-align: center;
+            -webkit-transition: background-color .218s, border-color .218s, box-shadow .218s;
+            transition: background-color .218s, border-color .218s, box-shadow .218s;
+            vertical-align: middle;
+            white-space: nowrap;
+            width: auto;
+            max-width: 400px;
+            min-width: min-content;
+            margin: 10px auto 0 auto;
+            display: block;
+        }}
+
+        .gsi-material-button .gsi-material-button-icon {{
+            height: 20px;
+            margin-right: 12px;
+            min-width: 20px;
+            width: 20px;
+        }}
+
+        .gsi-material-button .gsi-material-button-content-wrapper {{
+            -webkit-align-items: center;
+            align-items: center;
+            display: flex;
+            -webkit-flex-direction: row;
+            flex-direction: row;
+            -webkit-flex-wrap: nowrap;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: space-between;
+            position: relative;
+            width: 100%;
+        }}
+
+        .gsi-material-button .gsi-material-button-contents {{
+            -webkit-flex-grow: 1;
+            flex-grow: 1;
+            font-family: 'Roboto', arial, sans-serif;
+            font-weight: 500;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            vertical-align: top;
+        }}
+
+        .gsi-material-button .gsi-material-button-state {{
+            -webkit-transition: opacity .218s;
+            transition: opacity .218s;
+            bottom: 0;
+            left: 0;
+            opacity: 0;
+            position: absolute;
+            right: 0;
+            top: 0;
+        }}
+
+        .gsi-material-button:disabled {{
+            cursor: default;
+            background-color: #ffffff61;
+            border-color: #1f1f1f1f;
+        }}
+
+        .gsi-material-button:disabled .gsi-material-button-contents {{
+            opacity: 38%;
+        }}
+
+        .gsi-material-button:disabled .gsi-material-button-icon {{
+            opacity: 38%;
+        }}
+
+        .gsi-material-button:not(:disabled):active .gsi-material-button-state, 
+        .gsi-material-button:not(:disabled):focus .gsi-material-button-state {{
+            background-color: #303030;
+            opacity: 12%;
+        }}
+
+        .gsi-material-button:not(:disabled):hover {{
+            -webkit-box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
+            box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
+        }}
+
+        .gsi-material-button:not(:disabled):hover .gsi-material-button-state {{
+            background-color: #303030;
+            opacity: 8%;
+        }}
+        
+        
+        a {{
+            color: #3b82f6;
+            text-decoration: none;
+        }}
+
+        a:hover {{
+            text-decoration: underline;
+        }}
+        
+        code {{
+            background-color: #f1f5f9;
+            padding: 2px 4px;
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 13px;
+            color: #334155;
+        }}
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <div class="logo-container">
+            <div class="logo">Raypath</div>
+        </div>
+        <h2>Login</h2>
+        <p class="subtitle">Access your Raypath Admin UI.</p>
+        <div class="info-box">
+            <div class="info-header">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10"></circle>
+                    <line x1="12" y1="16" x2="12" y2="12"></line>
+                    <line x1="12" y1="8" x2="12.01" y2="8"></line>
+                </svg>
+                Single Sign-On
+            </div>
+            <p>Sign in securely with your organization's authentication provider.</p>
+        </div>"""
+
+    # Add Google login button if configured
+    if providers.get('google', False):
+        html_template += f"""
+            <button class="gsi-material-button" onclick="window.location.href='{sso_redirect_url}?provider=google'">
+                <div class="gsi-material-button-state"></div>
+                <div class="gsi-material-button-content-wrapper">
+                    <div class="gsi-material-button-icon">
+                        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" xmlns:xlink="http://www.w3.org/1999/xlink" style="display: block;">
+                            <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
+                            <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
+                            <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
+                            <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
+                            <path fill="none" d="M0 0h48v48H0z"></path>
+                        </svg>
+                    </div>
+                    <span class="gsi-material-button-contents">Sign in with Google</span>
+                    <span style="display: none;">Sign in with Google</span>
+                </div>
+            </button>"""
+
+
+
+    html_template += f"""
+        </div>
+    </div>
+</body>
+</html>"""
+
+    return html_template


### PR DESCRIPTION
- Add sso_login.py template with Google Material Design button
- Replace auto-redirect with login page showing available SSO providers
- Add /sso/redirect endpoint for provider-specific authentication
- Show 'Sign in with Google' button with official Material Design styling
