### PR TITLE
Fix Litellm config file

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -4,6 +4,6 @@ model_list:
       model: openai/*
       api_base: https://exampleopenaiendpoint-production-0ee2.up.railway.app/
 
-general_settings:
+litellm_settings:
   default_internal_user_params:
     user_role: "proxy_admin"  # Give new SSO users admin access


### PR DESCRIPTION
- Replaced "general_settings" by "litellm_settings" at the proxy_config.yaml file.
